### PR TITLE
remove start argument from listener calls

### DIFF
--- a/api.go
+++ b/api.go
@@ -113,7 +113,6 @@ func (h *Handler) ServeUnix(systemGroup, addr string) error {
 
 func (h *Handler) listenAndServe(proto, addr, group string) error {
 	var (
-		start = make(chan struct{})
 		l     net.Listener
 		err   error
 		spec  string
@@ -126,9 +125,9 @@ func (h *Handler) listenAndServe(proto, addr, group string) error {
 
 	switch proto {
 	case "tcp":
-		l, spec, err = newTCPListener(group, addr, start)
+		l, spec, err = newTCPListener(group, addr)
 	case "unix":
-		l, spec, err = newUnixListener(addr, group, start)
+		l, spec, err = newUnixListener(addr, group)
 	}
 
 	if spec != "" {
@@ -138,7 +137,6 @@ func (h *Handler) listenAndServe(proto, addr, group string) error {
 		return err
 	}
 
-	close(start)
 	return server.Serve(l)
 }
 

--- a/tcp_listener.go
+++ b/tcp_listener.go
@@ -16,9 +16,8 @@ const (
 func newTCPListener(
 	volumeDriverName string,
 	address string,
-	start <-chan struct{},
 ) (net.Listener, string, error) {
-	listener, err := sockets.NewTCPSocket(address, nil, start)
+	listener, err := sockets.NewTCPSocket(address, nil)
 	if err != nil {
 		return nil, "", err
 	}

--- a/unix_listener.go
+++ b/unix_listener.go
@@ -17,13 +17,12 @@ const (
 func newUnixListener(
 	volumeDriverName string,
 	group string,
-	start <-chan struct{},
 ) (net.Listener, string, error) {
 	path, err := fullSocketAddress(volumeDriverName)
 	if err != nil {
 		return nil, "", err
 	}
-	listener, err := sockets.NewUnixSocket(path, group, start)
+	listener, err := sockets.NewUnixSocket(path, group)
 	if err != nil {
 		return nil, "", err
 	}

--- a/unix_listener_unsupported.go
+++ b/unix_listener_unsupported.go
@@ -14,7 +14,6 @@ var (
 func newUnixListener(
 	volumeDriverName string,
 	group string,
-	start <-chan struct{},
 ) (net.Listener, string, error) {
 	return nil, "", errOnlySupportedOnLinuxAndFreeBSD
 }


### PR DESCRIPTION
- since this change :  https://github.com/docker/docker/commit/ca5795cef810c85f101eb0aa3efe3ec8d756490b,
  the code would not compile anymore, hence the need for removal of the third start argument
